### PR TITLE
Convert readthedocs links for their .org -> .io migration for hosted projects

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ the [Firefox browser][ffx] and [Firefox OS][fxos].
 
 Interested in contributing to the development of Mozilla's Push Service?
 Complete documentation on the Push Service, History, and how to get involved
-can be found at [the Push Service's documentation](http://mozilla-push-service.readthedocs.org/).
+can be found at [the Push Service's documentation](https://mozilla-push-service.readthedocs.io/).
 
 ##### Bugs List: [waffle.io/mozilla-services/push-service](https://waffle.io/mozilla-services/push-service/)
 
@@ -29,7 +29,7 @@ Server + File Watching:
 mkdocs serve --dev-addr localhost:9032
 ```
 
-Publishing to http://mozilla-push-service.readthedocs.org
+Publishing to https://mozilla-push-service.readthedocs.io
 
 ```
 # Documentation is built automatically from this repository.

--- a/docs/index.md
+++ b/docs/index.md
@@ -5,7 +5,7 @@ Mozilla Push Service is the server-side project supporting Push Notifications in
 [autopush](https://github.com/mozilla-services/autopush). You can
 learn how to use the web based API to push messages to web
 applications running Push by reading the [autopush HTTP API
-document](http://autopush.readthedocs.org/en/latest/http.html).
+document](https://autopush.readthedocs.io/en/latest/http.html).
 
 ## Architecture
 
@@ -73,7 +73,7 @@ on MDN.
 
 If you are creating a service that sends Push messages to remote
 browser applications, see [HTTP Endpoints for
-Notifications](http://autopush.readthedocs.org/en/latest/http.html).
+Notifications](https://autopush.readthedocs.io/en/latest/http.html).
 
 ## Terminology
 


### PR DESCRIPTION
As per [their blog post of the 27th April](https://blog.readthedocs.com/securing-subdomains/) ‘Securing subdomains’:

> Starting today, Read the Docs will start hosting projects from subdomains on the domain readthedocs.io, instead of on readthedocs.org. This change addresses some security concerns around site cookies while hosting user generated data on the same domain as our dashboard.

Test Plan: Manually visited all the links I’ve modified.
